### PR TITLE
Stricter straight rules: same-suit, edge-only extensions, K→A continuity, joker-edge handling

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -64,6 +64,14 @@
     }
 
     function cardLabel(c){ return c.joker ? "🃏" : `${c.rank}${c.suit}`; }
+    function cardColorClass(c){
+      if(c.joker || !c.suit) return "text-slate-900";
+      return RED_SUITS.has(c.suit) ? "text-red-600" : "text-slate-900";
+    }
+    function cardColorWhenActive(c, active){
+      if(active) return "text-white";
+      return cardColorClass(c);
+    }
     function cardPoint(c){ return c.joker ? 30 : (CARD_POINTS[c.rank] ?? Number(c.rank)); }
 
     function newDeck(){
@@ -117,71 +125,100 @@
       return naturals.every(c => c.rank === naturals[0].rank);
     }
 
-    function validateStraight(cards, kind){
-      if(kind === "straight4") return canBuildStraight(cards, 4, "any");
-      if(kind === "crazy13") return canBuildStraight(cards, 13, "any", true);
-      if(kind === "color13") return canBuildStraight(cards, 13, "color", true);
-      if(kind === "royal13") return canBuildStraight(cards, 13, "suit", true);
-      return false;
+    function sequenceRank(start, offset){
+      return ((start - 1 + offset) % 13) + 1;
     }
 
-    function canBuildStraight(cards, len, lock, noAdjacentJokers=false){
-      if(cards.length !== len) return false;
-      const jokers = cards.filter(c=>c.joker);
+    function rankForCard(card){
+      return rankNum(card.rank, false);
+    }
+
+    function sameSuitNaturals(cards){
       const naturals = cards.filter(c=>!c.joker);
+      if(!naturals.length) return true;
+      return naturals.every(c=>c.suit === naturals[0].suit);
+    }
 
-      let targets = [];
-      if(len === 13) {
-        targets = [Array.from({length:13}, (_,i)=>i+1)]; // A..K
-      } else {
-        for(let s=1;s<=10;s++) targets.push([s,s+1,s+2,s+3]);
-        targets.push([11,12,13,14]); // JQKA
+    function findUnorderedStraightAssignment(cards, len){
+      if(cards.length !== len || len < 3 || len > 13) return null;
+      if(!sameSuitNaturals(cards)) return null;
+      const naturals = cards.filter(c=>!c.joker);
+      const jokers = cards.filter(c=>c.joker);
+      const naturalByRank = new Map();
+      for(const c of naturals){
+        const r = rankForCard(c);
+        const list = naturalByRank.get(r) || [];
+        list.push(c);
+        naturalByRank.set(r, list);
       }
+      for(const cardsAtRank of naturalByRank.values()) if(cardsAtRank.length > 1) return null;
 
-      for(const seq of targets){
-        const used = new Set();
-        const slots = Array(seq.length).fill(null);
+      for(let start=1; start<=13; start++){
+        const slots = Array(len).fill(null);
         let ok = true;
-        for(const card of naturals){
-          let placed = false;
-          for(let i=0;i<seq.length;i++){
-            if(used.has(i)) continue;
-            const v = rankNum(card.rank, seq.includes(14));
-            if(v !== seq[i]) continue;
-            if(lock === "color"){
-              const colorSet = RED_SUITS.has(card.suit) ? RED_SUITS : BLACK_SUITS;
-              const existing = naturals.find(n => n !== card && n.suit && slots.some((s,idx)=>s===n && (seq[idx]===rankNum(n.rank, seq.includes(14)))));
-              if(existing && !colorSet.has(existing.suit)) continue;
-            }
-            if(lock === "suit"){
-              const existingSuit = naturals[0]?.suit;
-              if(existingSuit && card.suit !== existingSuit) continue;
-            }
-            slots[i] = card;
-            used.add(i);
-            placed = true;
-            break;
-          }
-          if(!placed){ ok = false; break; }
+        for(let i=0;i<len;i++){
+          const r = sequenceRank(start, i);
+          const list = naturalByRank.get(r);
+          if(list?.length) slots[i] = list[0];
         }
+        const missing = slots.filter(x=>!x).length;
+        if(missing !== jokers.length){ ok = false; }
         if(!ok) continue;
-        let j = 0;
-        for(let i=0;i<slots.length;i++) if(!slots[i]) slots[i] = {joker:true, id:`j-${j++}`};
-        if(noAdjacentJokers){
-          for(let i=1;i<slots.length;i++) if(slots[i].joker && slots[i-1].joker) { ok = false; break; }
-          if(!ok) continue;
-        }
-        if(lock === "color"){
-          const naturalColors = naturals.map(c=>RED_SUITS.has(c.suit)?"red":"black");
-          if(naturalColors.length && new Set(naturalColors).size > 1) continue;
-        }
-        if(lock === "suit"){
-          const suits = naturals.map(c=>c.suit);
-          if(suits.length && new Set(suits).size > 1) continue;
-        }
-        return true;
+        let ji = 0;
+        for(let i=0;i<len;i++) if(!slots[i]) slots[i] = jokers[ji++];
+        return { start, slots };
       }
-      return false;
+      return null;
+    }
+
+    function resolveOrderedStraight(cards){
+      const len = cards.length;
+      if(len < 3 || len > 13) return null;
+      if(!sameSuitNaturals(cards)) return null;
+      for(let start=1; start<=13; start++){
+        let ok = true;
+        const ranks = [];
+        for(let i=0;i<len;i++){
+          const expected = sequenceRank(start, i);
+          ranks.push(expected);
+          const card = cards[i];
+          if(!card.joker && rankForCard(card) !== expected){ ok = false; break; }
+        }
+        if(ok) return { start, ranks };
+      }
+      return null;
+    }
+
+    function normalizeStraightCards(cards){
+      const assignment = findUnorderedStraightAssignment(cards, cards.length);
+      return assignment ? assignment.slots : null;
+    }
+
+    function validateStraight(cards, kind){
+      const len = kind === "straight4" ? 4 : 13;
+      return !!findUnorderedStraightAssignment(cards, len);
+    }
+
+    function canExtendStraightOnSide(meldCards, addedCards, side){
+      if(!addedCards.length) return null;
+      let base = meldCards;
+      let baseState = resolveOrderedStraight(base);
+      if(!baseState){
+        base = normalizeStraightCards(meldCards) || meldCards;
+        baseState = resolveOrderedStraight(base);
+      }
+      if(!baseState) return null;
+
+      const candidate = side === "left" ? [...addedCards, ...base] : [...base, ...addedCards];
+      if(candidate.length > 13) return null;
+      const candidateState = resolveOrderedStraight(candidate);
+      if(!candidateState) return null;
+
+      const offset = side === "left" ? addedCards.length : 0;
+      for(let i=0;i<baseState.ranks.length;i++){
+        if(candidateState.ranks[offset+i] !== baseState.ranks[i]) return null;
+      }
+      return candidate;
     }
 
     function validateMeld(cards, type){
@@ -231,16 +268,18 @@
       return out;
     }
 
-    function canLayoffToMeld(meld, cards){
-      if(!cards.length) return false;
-      const merged = [...meld.cards, ...cards];
+    function applyLayoffToMeld(meld, cards){
+      if(!cards.length) return null;
       if(meld.type === "set3"){
+        const merged = [...meld.cards, ...cards];
         const naturals = merged.filter(c=>!c.joker);
-        return naturals.length === 0 || naturals.every(c=>c.rank === naturals[0].rank);
+        return naturals.length === 0 || naturals.every(c=>c.rank === naturals[0].rank) ? merged : null;
       }
-      const type = meld.type;
-      const straightType = type === "straight4" ? "straight4" : type;
-      return canBuildStraight(merged, merged.length, straightType === "straight4" ? "any" : (straightType === "color13" ? "color" : straightType === "royal13" ? "suit" : "any"), straightType !== "straight4");
+      return canExtendStraightOnSide(meld.cards, cards, "right") || canExtendStraightOnSide(meld.cards, cards, "left");
+    }
+
+    function canLayoffToMeld(meld, cards){
+      return !!applyLayoffToMeld(meld, cards);
     }
 
     function newGameState(humanName, aiLevel){
@@ -378,7 +417,8 @@
           const comp = findMatchingComponent(roundDef.components, done, cards);
           if(!comp) return { ...prev, message: "Selected cards do not match an unmet objective meld." };
           const next = structuredClone(prev);
-          next.round.tableMelds.push({ id: uid(), owner: "human", type: comp, cards });
+          const meldCards = comp === "set3" ? cards : normalizeStraightCards(cards);
+          next.round.tableMelds.push({ id: uid(), owner: "human", type: comp, cards: meldCards || cards });
           next.turnAddedCardIds = [...(next.turnAddedCardIds || []), ...cards.map(c=>c.id)];
           next.round.laid.human.push(comp);
           const ids = new Set(cards.map(c=>c.id));
@@ -399,7 +439,9 @@
           if(!canLayoffToMeld(target, cards)) return { ...prev, message:"Those cards cannot be added to that meld." };
           const next = structuredClone(prev);
           const m = next.round.tableMelds.find(x=>x.id===meldTarget);
-          m.cards.push(...cards);
+          const applied = applyLayoffToMeld(m, cards);
+          if(!applied) return { ...prev, message:"Those cards cannot be added to that meld." };
+          m.cards = applied;
           next.turnAddedCardIds = [...(next.turnAddedCardIds || []), ...cards.map(c=>c.id)];
           const ids = new Set(cards.map(c=>c.id));
           next.round.hands.human = next.round.hands.human.filter(c=>!ids.has(c.id));
@@ -493,7 +535,7 @@
           <div className="text-sm">Computer hand: {computerHandCount} cards</div>
           <div className="flex gap-2 mt-2">
             <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.deck.length} onClick={()=>draw("deck")}>Draw deck ({state.round.deck.length})</button>
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.discard.length} onClick={()=>draw("discard")}>Draw discard ({state.round.discard.length ? cardLabel(state.round.discard[state.round.discard.length-1]) : "—"})</button>
+            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.discard.length} onClick={()=>draw("discard")}>Draw discard ({state.round.discard.length ? <span className={cardColorClass(state.round.discard[state.round.discard.length-1])}>{cardLabel(state.round.discard[state.round.discard.length-1])}</span> : "—"})</button>
             <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || !state.hasDrawn || humanObjectiveComplete} onClick={layObjective}>Lay objective meld</button>
             <select className="border rounded px-2 py-1" value={meldTarget} onChange={e=>setMeldTarget(e.target.value)}>
               <option value="">Select meld target</option>
@@ -518,7 +560,7 @@
           <div className="flex flex-wrap gap-2">
             {sortHand(humanHand, state.handSortMode || "rank").map(c=>{
               const active = selected.includes(c.id);
-              return <button key={c.id} onClick={()=>toggleSelect(c.id)} className={`px-2 py-1 rounded border ${active?"bg-blue-600 text-white":"bg-white"}`}>{cardLabel(c)}</button>
+              return <button key={c.id} onClick={()=>toggleSelect(c.id)} className={`px-2 py-1 rounded border ${active?"bg-blue-600 text-white":"bg-white"} ${cardColorWhenActive(c, active)}`}>{cardLabel(c)}</button>
             })}
           </div>
         </section>
@@ -526,7 +568,7 @@
         <section className="p-3 rounded bg-white shadow">
           <div className="font-semibold">Table melds</div>
           <div className="grid md:grid-cols-2 gap-2 mt-2">
-            {state.round.tableMelds.map(m=><div className="border rounded p-2" key={m.id}><div className="text-sm font-medium">{m.owner} — {componentDesc(m.type)}</div><div className="flex flex-wrap gap-1">{m.cards.map(c=><span key={c.id} className={`px-1.5 py-0.5 rounded ${state.turnAddedCardIds?.includes(c.id) ? "bg-amber-200 ring-1 ring-amber-400" : ""}`}>{cardLabel(c)}</span>)}</div></div>)}
+            {state.round.tableMelds.map(m=><div className="border rounded p-2" key={m.id}><div className="text-sm font-medium">{m.owner} — {componentDesc(m.type)}</div><div className="flex flex-wrap gap-1">{m.cards.map(c=><span key={c.id} className={`px-1.5 py-0.5 rounded ${cardColorClass(c)} ${state.turnAddedCardIds?.includes(c.id) ? "bg-amber-200 ring-1 ring-amber-400" : ""}`}>{cardLabel(c)}</span>)}</div></div>)}
             {!state.round.tableMelds.length && <div className="text-sm text-slate-600">No melds yet.</div>}
           </div>
         </section>
@@ -614,7 +656,8 @@
         const used = new Set();
         for(const m of newMelds){
           m.cards.forEach(c=>used.add(c.id));
-          next.round.tableMelds.push({ id: uid(), owner: "computer", type: m.type, cards: m.cards });
+          const meldCards = m.type === "set3" ? m.cards : normalizeStraightCards(m.cards);
+          next.round.tableMelds.push({ id: uid(), owner: "computer", type: m.type, cards: meldCards || m.cards });
           next.turnAddedCardIds.push(...m.cards.map(c=>c.id));
           next.round.laid.computer.push(m.type);
         }
@@ -629,7 +672,9 @@
           for(const card of [...next.round.hands.computer]){
             const target = next.round.tableMelds.find(m=>canLayoffToMeld(m,[card]));
             if(target){
-              target.cards.push(card);
+              const applied = applyLayoffToMeld(target, [card]);
+              if(!applied) continue;
+              target.cards = applied;
               next.turnAddedCardIds.push(card.id);
               next.round.hands.computer = next.round.hands.computer.filter(c=>c.id!==card.id);
               progressed = next.aiLevel !== "Easy";
@@ -649,7 +694,6 @@
       next.round.hands.computer = next.round.hands.computer.filter(c=>c.id!==discardCard.id);
       next.currentPlayer = "human";
       next.hasDrawn = false;
-      next.turnAddedCardIds = [];
       next.message = `${next.computerName} took a turn and discarded ${cardLabel(discardCard)}.`;
 
       return maybeFinishRound(next, "computer");


### PR DESCRIPTION
### Motivation
- Straights must follow game rules more strictly: all natural cards in a straight must be the same suit and straights are circular (K connects to A). 
- Players should only be able to add cards to the ends of a straight meld (left or right), not insert in the middle. 
- Joker usage in straights must be interpreted as an edge placeholder so follow-up cards continue beyond what the joker represents. 
- AI and UI behavior must match the same validation and normalization rules used for human play.

### Description
- Replaced the old straight builder with sequence-based helpers including `sequenceRank`, `findUnorderedStraightAssignment`, `resolveOrderedStraight`, and `normalizeStraightCards` to validate and normalize straights under circular rank order and same-suit constraints. 
- Added `canExtendStraightOnSide` to check legal left/right extensions and `applyLayoffToMeld` to compute and apply valid layoff results, and updated `canLayoffToMeld` to use it. 
- Normalized straight meld ordering when laying new melds (`layObjective`) and changed human `addToMeld` and AI layoff logic to use `applyLayoffToMeld` so only edge additions are permitted and joker-edge behavior is preserved. 
- Minor UI improvements: card coloring for suits (`cardColorClass` / `cardColorWhenActive`) and render adjustments for discard and table melds to reflect suit coloring.

### Testing
- Ran `git diff --check` to ensure no whitespace/diff issues and the tree was clean, which succeeded. 
- Served the app locally with `python -m http.server` and exercised logic in-page to validate behavior, which started successfully. 
- Executed a Playwright evaluation against the running page that confirmed rule behavior: `[2♠,3♠,4♠,Joker]` accepts `6♠` and rejects `5♠`, `[Joker,6♠,7♠,8♠]` accepts `4♠` and rejects `5♠`, `Q♥,K♥,A♥` is valid, and mixed-suit straights are invalid, and all checks passed. 
- No automated unit tests were added in this change set; validation was done via runtime checks described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6d2c0ed88328851e5e74b01b633f)