### PR TITLE
Allow manual hand reordering before draw

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -672,7 +672,7 @@
               const isDropTarget = dragOverCardId === c.id && draggingCardId !== c.id;
               return <button
                 key={c.id}
-                draggable={state.currentPlayer === "human" && state.hasDrawn}
+                draggable={state.handSortMode === "manual" || (state.currentPlayer === "human" && state.hasDrawn)}
                 onDragStart={()=>setDraggingCardId(c.id)}
                 onDragOver={e=>{
                   if(state.handSortMode !== "manual") return;


### PR DESCRIPTION
### Motivation
- Manual drag-sorting became unusable at turn start because `draggable` was tied to `state.currentPlayer === "human" && state.hasDrawn`, preventing manual reordering when `handSortMode` is `manual` before a draw.

### Description
- Change the card `draggable` expression in `carioca-game.html` from `state.currentPlayer === "human" && state.hasDrawn` to `state.handSortMode === "manual" || (state.currentPlayer === "human" && state.hasDrawn)` so manual-mode reordering is allowed before draw while preserving draw-phase gating for gameplay drags.

### Testing
- Located affected references with `rg`, validated the edit with `git diff -- carioca-game.html`, committed the change and confirmed with `git show --stat --oneline HEAD`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e289000c88328bfb42324312170fc)