### PR TITLE
Add game deletion with confirmation in Carioca game UI

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -56,7 +56,8 @@
 
     const ls = {
       read(k, fb){ try{ const v = localStorage.getItem(k); return v ? JSON.parse(v) : fb; } catch { return fb; } },
-      write(k, v){ try{ localStorage.setItem(k, JSON.stringify(v)); } catch {} }
+      write(k, v){ try{ localStorage.setItem(k, JSON.stringify(v)); } catch {} },
+      remove(k){ try{ localStorage.removeItem(k); } catch {} }
     };
 
     function randomComputerName(){
@@ -416,6 +417,39 @@
         if(s){ setGameId(id); setState(s); setSelected([]); }
       }
 
+      function deleteGame(){
+        if(!gameId) return;
+        const meta = games.find(g=>g.id===gameId);
+        const ok = confirm(`Delete game “${meta?.name || "this game"}”? This cannot be undone.`);
+        if(!ok) return;
+
+        ls.remove(GAME_PREFIX + gameId);
+        const remaining = games.filter(g=>g.id!==gameId);
+
+        if(!remaining.length){
+          const id = uid();
+          const freshMeta = { id, name: "Game 1", updatedAt: Date.now() };
+          const freshState = newGameState("Player", "Medium");
+          setGames([freshMeta]);
+          setGameId(id);
+          setState(freshState);
+          setSelected([]);
+          ls.write(GAME_PREFIX + id, freshState);
+          ls.write(GAMES_KEY, [freshMeta]);
+          ls.write(LAST_GAME_KEY, id);
+          return;
+        }
+
+        const nextGameId = remaining[0].id;
+        const nextState = ls.read(GAME_PREFIX + nextGameId, null);
+        setGames(remaining);
+        setGameId(nextGameId);
+        setState(nextState || newGameState("Player", "Medium"));
+        setSelected([]);
+        ls.write(GAMES_KEY, remaining);
+        ls.write(LAST_GAME_KEY, nextGameId);
+      }
+
       function draw(from){
         setState(prev=>{
           if(!prev || prev.phase !== "playing" || prev.currentPlayer !== "human" || prev.hasDrawn) return prev;
@@ -614,6 +648,7 @@
               {games.map(g=><option key={g.id} value={g.id}>{g.name}</option>)}
             </select>
             <button className="px-3 py-1 rounded bg-slate-800 text-white" onClick={createGame}>New Game</button>
+            <button className="px-3 py-1 rounded border border-red-300 text-red-700" onClick={deleteGame} disabled={!gameId}>Delete Game</button>
           </div>
         </header>
 


### PR DESCRIPTION
### Motivation

- Provide a safe way for users to remove saved games from localStorage with an explicit warning before irreversible deletion.
- Keep the app usable when the currently selected or last remaining game is deleted by ensuring a valid game remains selected.

### Description

- Added a `remove` helper to the `ls` localStorage wrapper as `ls.remove(k)` to delete individual keys from `localStorage`.
- Implemented `deleteGame()` which prompts the user with `confirm(...)` before removing the selected game's storage entry and metadata, then switches to a remaining game or creates a fresh default game if none remain.
- Added a `Delete Game` button in the header next to the `New Game` control and wired it to `deleteGame()` with a `disabled` state when no game is selected.

### Testing

- Ran `git diff --check` to validate whitespace and diff issues, which passed.
- Served the app with `python3 -m http.server 4173 --directory /workspace/carioca` and verified the page loaded successfully for UI validation.
- Ran a headless browser check via a Playwright script to load `http://127.0.0.1:4173/carioca-game.html` and capture a screenshot showing the updated header controls, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2c01b2e48328a1613ce7ed79cf66)