### PR TITLE
UI refresh, SVG card faces, drag-to-draw, and AI/turn state improvements

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -15,12 +15,12 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <style>html,body,#root{height:100%;}</style>
 </head>
-<body class="bg-slate-100 text-slate-900">
+<body class="bg-slate-950 text-slate-100">
   <div id="root"></div>
   <script type="text/babel">
     const { useEffect, useMemo, useState } = React;
 
-    const APP_VERSION = "v0.61";
+    const APP_VERSION = "v0.65";
 
     const NS = "carioca-game-v2";
     const GAMES_KEY = NS + ":games";
@@ -71,6 +71,26 @@
     function cardColorWhenActive(c, active){
       if(active) return "text-white";
       return cardColorClass(c);
+    }
+    function cardSuitColor(c){
+      if(c.joker || !c.suit) return "#1e293b";
+      return RED_SUITS.has(c.suit) ? "#dc2626" : "#0f172a";
+    }
+    function cardImageData(c, selected=false){
+      const rank = c.joker ? "JOKER" : c.rank;
+      const suit = c.joker ? "★" : c.suit;
+      const color = selected ? "#ffffff" : cardSuitColor(c);
+      const bg = selected ? "#2563eb" : "#ffffff";
+      const stroke = selected ? "#1d4ed8" : "#cbd5e1";
+      const top = c.joker ? "✨" : `${rank}${suit}`;
+      const center = c.joker ? "🃏" : suit;
+      const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+        <rect x='5' y='5' width='170' height='240' rx='18' fill='${bg}' stroke='${stroke}' stroke-width='6'/>
+        <text x='20' y='52' font-size='36' font-family='Inter,Arial,sans-serif' fill='${color}' font-weight='800'>${top}</text>
+        <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Inter,Arial,sans-serif' fill='${color}'>${center}</text>
+        <text x='160' y='226' text-anchor='end' font-size='36' font-family='Inter,Arial,sans-serif' fill='${color}' font-weight='800'>${top}</text>
+      </svg>`;
+      return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
     }
     function formatMeldLabel(meld, index){
       const cardsPreview = meld.cards.map(cardLabel).join(" ");
@@ -332,6 +352,8 @@
         },
         totals: { human: 0, computer: 0 },
         history: [],
+        lastDrawnCardId: null,
+        aiLastDrawFrom: null,
         message: "Game started.",
       };
     }
@@ -345,6 +367,7 @@
       const [draggingCardId, setDraggingCardId] = useState(null);
       const [dragOverCardId, setDragOverCardId] = useState(null);
       const [dragOverMeldId, setDragOverMeldId] = useState(null);
+      const [draggingDrawFrom, setDraggingDrawFrom] = useState(null);
 
       useEffect(()=>{
         if(!games.length){
@@ -373,7 +396,7 @@
 
       useEffect(()=>{
         if(!state || state.phase !== "playing" || state.currentPlayer !== "computer") return;
-        const t = setTimeout(()=>setState(prev=>runAiTurn(prev)), 700);
+        const t = setTimeout(()=>setState(prev=>runAiTurn(prev)), 1600);
         return ()=>clearTimeout(t);
       },[state]);
 
@@ -416,16 +439,27 @@
         if(s){ setGameId(id); setState(s); setSelected([]); }
       }
 
+      function drawRestriction(prev, from){
+        if(!prev || prev.phase !== "playing") return "The round is not in a playable state.";
+        if(prev.currentPlayer !== "human") return "It's not your turn yet.";
+        if(prev.hasDrawn) return "You already drew this turn. You must play and discard now.";
+        const src = from === "discard" ? prev.round.discard : prev.round.deck;
+        if(!src.length) return from === "discard" ? "Discard pile is empty." : "Deck is empty.";
+        return null;
+      }
+
       function draw(from){
         setState(prev=>{
-          if(!prev || prev.phase !== "playing" || prev.currentPlayer !== "human" || prev.hasDrawn) return prev;
+          const reason = drawRestriction(prev, from);
+          if(reason) return { ...prev, message: reason };
           const src = from === "discard" ? prev.round.discard : prev.round.deck;
-          if(!src.length) return { ...prev, message: "No cards available there." };
           const card = src[src.length-1];
           const next = structuredClone(prev);
           if(from === "discard") next.round.discard.pop(); else next.round.deck.pop();
           next.round.hands.human.push(card);
           next.hasDrawn = true;
+          next.lastDrawnCardId = card.id;
+          next.aiLastDrawFrom = null;
           next.laidObjectiveThisTurn = false;
           next.objectiveMeldIdsLaidThisTurn = [];
           next.turnAddedCardIds = [];
@@ -568,6 +602,7 @@
           next.round.discard.push(card);
           next.round.hands.human = next.round.hands.human.filter(c=>c.id!==card.id);
           next.hasDrawn = false;
+          next.lastDrawnCardId = null;
           next.laidObjectiveThisTurn = false;
           next.objectiveMeldIdsLaidThisTurn = [];
           next.currentPlayer = "computer";
@@ -593,6 +628,8 @@
             currentPlayer: prev.round.winner === "human" ? "human" : "computer",
             hasDrawn: false,
             laidObjectiveThisTurn: false,
+            lastDrawnCardId: null,
+            aiLastDrawFrom: null,
             objectiveMeldIdsLaidThisTurn: [],
             round: { deck, discard, hands, tableMelds: [], laid:{human:[],computer:[]}, winner:null },
             turnAddedCardIds: [],
@@ -601,130 +638,239 @@
         });
       }
 
+      function startDrawDrag(e, from){
+        const reason = drawRestriction(state, from);
+        if(reason){
+          e.preventDefault();
+          setState(prev=>prev ? { ...prev, message: reason } : prev);
+          return;
+        }
+        const source = from === "discard" ? state.round.discard : state.round.deck;
+        const card = source[source.length-1];
+        if(!card) return;
+        e.dataTransfer.effectAllowed = "move";
+        e.dataTransfer.setData("text/plain", `draw:${from}`);
+        const img = new Image();
+        img.src = cardImageData(card, false);
+        img.style.position = "absolute";
+        img.style.left = "-9999px";
+        img.style.width = "56px";
+        img.style.height = "80px";
+        document.body.appendChild(img);
+        e.dataTransfer.setDragImage(img, 28, 40);
+        setTimeout(()=>img.remove(), 0);
+        setDraggingDrawFrom(from);
+      }
+
+      function CardFace({ card, selected: isSelected=false, highlight=false, className="" }){
+        return <img
+          src={cardImageData(card, isSelected)}
+          alt={cardLabel(card)}
+          className={`h-20 w-14 rounded-lg border border-slate-300/80 shadow-sm bg-white object-cover select-none ${highlight ? "ring-2 ring-emerald-400" : ""} ${className}`}
+          draggable={false}
+        />;
+      }
+
       if(!state) return <div className="p-4">Loading…</div>;
 
       return <div className="max-w-6xl mx-auto p-4 space-y-4">
         <header className="flex flex-wrap gap-2 items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold">Carioca — Human vs Computer</h1>
-            <p className="text-xs text-slate-500">Version {APP_VERSION}</p>
+            <h1 className="text-2xl font-semibold tracking-tight">Carioca — Human vs Computer</h1>
+            <p className="text-xs text-slate-400">Version {APP_VERSION}</p>
           </div>
           <div className="flex gap-2 items-center">
-            <select className="border rounded px-2 py-1" value={gameId||""} onChange={e=>switchGame(e.target.value)}>
+            <select className="border border-white/15 rounded-lg px-2 py-1 bg-slate-900/80" value={gameId||""} onChange={e=>switchGame(e.target.value)}>
               {games.map(g=><option key={g.id} value={g.id}>{g.name}</option>)}
             </select>
-            <button className="px-3 py-1 rounded bg-slate-800 text-white" onClick={createGame}>New Game</button>
+            <button className="px-3 py-1 rounded-lg bg-indigo-500 text-white hover:bg-indigo-400 transition" onClick={createGame}>New Game</button>
           </div>
         </header>
 
         <section className="grid md:grid-cols-3 gap-3">
-          <div className="p-3 rounded bg-white shadow">
+          <div className="p-3 rounded-2xl bg-white/10 backdrop-blur border border-white/10 shadow-lg">
             <div className="font-semibold">Players</div>
             <div>{state.humanName} (You)</div>
             <div>{state.computerName} (AI: {state.aiLevel})</div>
           </div>
-          <div className="p-3 rounded bg-white shadow">
+          <div className="p-3 rounded-2xl bg-white/10 backdrop-blur border border-white/10 shadow-lg">
             <div className="font-semibold">Round {state.roundIndex+1}: {roundDef.name}</div>
             <ul className="text-sm list-disc ml-5">
               {roundDef.components.map((c,i)=><li key={i}>{componentDesc(c)}</li>)}
             </ul>
           </div>
-          <div className="p-3 rounded bg-white shadow">
+          <div className="p-3 rounded-2xl bg-white/10 backdrop-blur border border-white/10 shadow-lg">
             <div className="font-semibold">Score</div>
             <div>{state.humanName}: {state.totals.human}</div>
             <div>{state.computerName}: {state.totals.computer}</div>
           </div>
         </section>
 
-        <section className="p-3 rounded bg-white shadow">
-          <div className="font-semibold">Turn: {state.currentPlayer === "human" ? "You" : state.computerName}</div>
-          <div className="text-sm text-slate-700">{state.message}</div>
-          <div className="text-sm">Computer hand: {computerHandCount} cards</div>
-          <div className="flex gap-2 mt-2">
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.deck.length} onClick={()=>draw("deck")}>Draw deck ({state.round.deck.length})</button>
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.discard.length} onClick={()=>draw("discard")}>Draw discard ({state.round.discard.length ? <span className={cardColorClass(state.round.discard[state.round.discard.length-1])}>{cardLabel(state.round.discard[state.round.discard.length-1])}</span> : "—"})</button>
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || !state.hasDrawn || humanObjectiveComplete} onClick={layObjective}>Lay objective meld</button>
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || !state.hasDrawn || humanObjectiveComplete || !(state.objectiveMeldIdsLaidThisTurn||[]).length} onClick={rollbackObjectiveMelds}>Rollback objective meld(s)</button>
-            <select className="border rounded px-2 py-1" value={meldTarget} onChange={e=>setMeldTarget(e.target.value)}>
-              <option value="">Select meld target</option>
-              {state.round.tableMelds.map((m, i)=><option key={m.id} value={m.id}>{formatMeldLabel(m, i)}</option>)}
-            </select>
-            <button className="px-2 py-1 border rounded" disabled={state.currentPlayer!=="human" || !state.hasDrawn || state.laidObjectiveThisTurn} onClick={addToMeld}>Add to meld</button>
-            <button className="px-2 py-1 border rounded bg-slate-900 text-white" disabled={state.currentPlayer!=="human" || !state.hasDrawn} onClick={discard}>Discard</button>
+        <section className="p-4 rounded-3xl bg-gradient-to-b from-emerald-900 via-emerald-800 to-emerald-900 border border-emerald-600/40 shadow-2xl space-y-4">
+          <div className="flex items-start justify-between gap-3 text-emerald-50">
+            <div>
+              <div className="font-semibold">Turn: {state.currentPlayer === "human" ? "You" : state.computerName}</div>
+              <div className="text-sm text-emerald-100/90">{state.message}</div>
+            </div>
+            <div className="text-xs px-2 py-1 rounded-full bg-emerald-950/60 border border-emerald-200/20">Computer hand: {computerHandCount} cards</div>
           </div>
-        </section>
 
-        <section className="p-3 rounded bg-white shadow">
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <div className="font-semibold">Your hand ({humanHand.length})</div>
-            <label className="text-xs text-slate-600 flex items-center gap-2">
-              Sort by
-              <select className="border rounded px-2 py-1 text-sm" value={state.handSortMode || "manual"} onChange={e=>setHandSortMode(e.target.value)}>
-                <option value="manual">Manual</option>
-                <option value="rank">Rank</option>
-                <option value="suit">Suit</option>
+          <div className="rounded-2xl border border-emerald-300/30 bg-emerald-950/35 p-3">
+            <div className="text-xs uppercase tracking-widest text-emerald-200/80 mb-2">Opponent</div>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-emerald-100">{state.computerName}</div>
+                <div className="text-xs text-emerald-200/80">AI opponent</div>
+              </div>
+              <div className="flex items-end gap-1">
+                <div className="text-3xl">🧑‍💻</div>
+                <div className="text-2xl -translate-y-1">🖐️</div>
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5 min-h-[74px] items-end">
+              {Array.from({ length: computerHandCount }).map((_, idx)=><div key={idx} className="h-20 w-14 rounded-lg bg-gradient-to-br from-slate-100 to-slate-300 border border-slate-300/80 shadow" />)}
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-[1fr_auto_1fr] gap-3 items-start">
+            <div className="rounded-2xl bg-emerald-950/40 border border-emerald-300/20 p-3">
+              <div className="text-xs uppercase tracking-widest text-emerald-200/80 mb-2">Deck</div>
+              <div className="flex items-center gap-3">
+                <div
+                  className={`relative h-20 w-14 cursor-grab active:cursor-grabbing ${state.aiLastDrawFrom === "deck" ? "ring-2 ring-amber-300 rounded-lg" : ""}`}
+                  draggable={true}
+                  onDragStart={(e)=>startDrawDrag(e, "deck")}
+                  onDragEnd={()=>setDraggingDrawFrom(null)}
+                  title="Drag this to your hand to draw"
+                >
+                  <div className="absolute inset-0 translate-x-1 translate-y-1 rounded-xl bg-slate-200/40" />
+                  <div className="absolute inset-0 rounded-xl border border-slate-200/70 bg-gradient-to-br from-slate-100 to-slate-300 shadow-md" />
+                </div>
+                <button className="px-2 py-1 border border-white/20 rounded-lg bg-slate-900/60 text-xs" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.deck.length} onClick={()=>draw("deck")}>Draw ({state.round.deck.length})</button>
+              </div>
+            </div>
+
+            <div className="text-3xl text-emerald-100/80 self-center">VS</div>
+
+            <div className="rounded-2xl bg-emerald-950/40 border border-emerald-300/20 p-3">
+              <div className="text-xs uppercase tracking-widest text-emerald-200/80 mb-2">Discard</div>
+              <div className="flex items-center gap-3">
+                <div
+                  className={`h-20 w-14 rounded-lg border border-slate-200/70 bg-white/95 flex items-center justify-center shadow-md ${state.aiLastDrawFrom === "discard" ? "ring-2 ring-amber-300" : ""} ${state.round.discard.length ? "cursor-grab active:cursor-grabbing" : ""}`}
+                  draggable={!!state.round.discard.length}
+                  onDragStart={(e)=>startDrawDrag(e, "discard")}
+                  onDragEnd={()=>setDraggingDrawFrom(null)}
+                  title="Drag this to your hand to take discard"
+                >
+                  {state.round.discard.length ? <CardFace card={state.round.discard[state.round.discard.length-1]} className="h-20 w-14" /> : <span className="text-slate-400">—</span>}
+                </div>
+                <button className="px-2 py-1 border border-white/20 rounded-lg bg-slate-900/60 text-xs" disabled={state.currentPlayer!=="human" || state.hasDrawn || !state.round.discard.length} onClick={()=>draw("discard")}>Take discard</button>
+              </div>
+            </div>
+          </div>
+
+          <section className="p-3 rounded-2xl bg-emerald-950/40 border border-emerald-300/20">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-semibold text-emerald-50">Your hand ({humanHand.length})</div>
+              <label className="text-xs text-emerald-100 flex items-center gap-2">Sort by
+                <select className="border border-white/20 rounded-lg px-2 py-1 text-sm bg-slate-900/70" value={state.handSortMode || "manual"} onChange={e=>setHandSortMode(e.target.value)}>
+                  <option value="manual">Manual</option>
+                  <option value="rank">Rank</option>
+                  <option value="suit">Suit</option>
+                </select>
+              </label>
+            </div>
+            <div className="relative">
+              <div className="absolute left-3 right-3 -bottom-3 h-8 rounded-full bg-amber-200/30 blur-md" />
+              <div className="absolute -bottom-1 left-8 text-2xl">✋</div>
+              <div className="absolute -bottom-1 right-8 text-2xl -scale-x-100">✋</div>
+              <div className="relative z-10 flex flex-wrap gap-1.5 pb-3 min-h-[98px]"
+                onDragOver={e=>{
+                  if(!draggingDrawFrom) return;
+                  e.preventDefault();
+                }}
+                onDrop={e=>{
+                  e.preventDefault();
+                  if(draggingDrawFrom){
+                    draw(draggingDrawFrom);
+                    setDraggingDrawFrom(null);
+                  }
+                }}
+              >
+                {(state.handSortMode === "manual" ? humanHand : sortHand(humanHand, state.handSortMode || "rank")).map(c=>{
+                  const active = selected.includes(c.id);
+                  const isDropTarget = dragOverCardId === c.id && draggingCardId !== c.id;
+                  const isNewlyDrawn = state.lastDrawnCardId === c.id;
+                  return <button
+                    key={c.id}
+                    draggable={true}
+                    onDragStart={()=>setDraggingCardId(c.id)}
+                    onDragOver={e=>{
+                      if(state.handSortMode !== "manual") return;
+                      e.preventDefault();
+                      setDragOverCardId(c.id);
+                    }}
+                    onDrop={e=>{
+                      e.preventDefault();
+                      if(state.handSortMode === "manual") moveCardInHand(draggingCardId, c.id);
+                      setDraggingCardId(null);
+                      setDragOverCardId(null);
+                    }}
+                    onDragEnd={()=>{ setDraggingCardId(null); setDragOverCardId(null); setDragOverMeldId(null); }}
+                    onClick={()=>toggleSelect(c.id)}
+                    className={`rounded-lg transition-transform hover:-translate-y-1 ${cardColorWhenActive(c, active)} ${isNewlyDrawn ? "ring-2 ring-amber-300 ring-offset-2 ring-offset-emerald-900" : ""}`}
+                  ><CardFace card={c} selected={active} highlight={isDropTarget} /></button>;
+                })}
+              </div>
+            </div>
+          </section>
+
+          <section className="p-3 rounded-2xl bg-emerald-950/40 border border-emerald-300/20">
+            <div className="flex flex-wrap gap-2">
+              <button className="px-2 py-1 border border-white/20 rounded-lg bg-slate-900/60 text-sm" disabled={state.currentPlayer!=="human" || !state.hasDrawn || humanObjectiveComplete} onClick={layObjective}>Lay objective meld</button>
+              <button className="px-2 py-1 border border-white/20 rounded-lg bg-slate-900/60 text-sm" disabled={state.currentPlayer!=="human" || !state.hasDrawn || humanObjectiveComplete || !(state.objectiveMeldIdsLaidThisTurn||[]).length} onClick={rollbackObjectiveMelds}>Rollback objective meld(s)</button>
+              <select className="border border-white/20 rounded-lg px-2 py-1 bg-slate-900/80 text-sm" value={meldTarget} onChange={e=>setMeldTarget(e.target.value)}>
+                <option value="">Select meld target</option>
+                {state.round.tableMelds.map((m, i)=><option key={m.id} value={m.id}>{formatMeldLabel(m, i)}</option>)}
               </select>
-            </label>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {(state.handSortMode === "manual" ? humanHand : sortHand(humanHand, state.handSortMode || "rank")).map(c=>{
-              const active = selected.includes(c.id);
-              const isDropTarget = dragOverCardId === c.id && draggingCardId !== c.id;
-              return <button
-                key={c.id}
-                draggable={state.handSortMode === "manual" || (state.currentPlayer === "human" && state.hasDrawn)}
-                onDragStart={()=>setDraggingCardId(c.id)}
-                onDragOver={e=>{
-                  if(state.handSortMode !== "manual") return;
-                  e.preventDefault();
-                  setDragOverCardId(c.id);
-                }}
-                onDrop={e=>{
-                  e.preventDefault();
-                  if(state.handSortMode === "manual") moveCardInHand(draggingCardId, c.id);
-                  setDraggingCardId(null);
-                  setDragOverCardId(null);
-                }}
-                onDragEnd={()=>{ setDraggingCardId(null); setDragOverCardId(null); setDragOverMeldId(null); }}
-                onClick={()=>toggleSelect(c.id)}
-                className={`px-2 py-1 rounded border ${active?"bg-blue-600 text-white":"bg-white"} ${cardColorWhenActive(c, active)} ${isDropTarget ? "ring-2 ring-emerald-500" : ""}`}
-              >{cardLabel(c)}</button>
-            })}
-          </div>
-        </section>
+              <button className="px-2 py-1 border border-white/20 rounded-lg bg-slate-900/60 text-sm" disabled={state.currentPlayer!=="human" || !state.hasDrawn || state.laidObjectiveThisTurn} onClick={addToMeld}>Add to meld</button>
+              <button className="px-2 py-1 border border-white/20 rounded-lg bg-indigo-500 text-white text-sm" disabled={state.currentPlayer!=="human" || !state.hasDrawn} onClick={discard}>Discard</button>
+            </div>
+          </section>
 
-        <section className="p-3 rounded bg-white shadow">
-          <div className="font-semibold">Table melds</div>
-          <div className="grid md:grid-cols-2 gap-2 mt-2">
-            {state.round.tableMelds.map((m, i)=>{
-              const isMeldDropTarget = dragOverMeldId === m.id;
-              return <div
-                className={`border rounded p-2 ${isMeldDropTarget ? "ring-2 ring-emerald-500 bg-emerald-50" : ""}`}
-                key={m.id}
-                onDragOver={e=>{
-                  if(!draggingCardId) return;
-                  e.preventDefault();
-                  setDragOverMeldId(m.id);
-                }}
-                onDragLeave={()=>{ if(dragOverMeldId === m.id) setDragOverMeldId(null); }}
-                onDrop={e=>{
-                  e.preventDefault();
-                  if(!draggingCardId) return;
-                  const hand = state.round.hands.human;
-                  const selectedSet = new Set(selected);
-                  const droppedIds = selectedSet.has(draggingCardId)
-                    ? hand.filter(c=>selectedSet.has(c.id)).map(c=>c.id)
-                    : [draggingCardId];
-                  setMeldTarget(m.id);
-                  addCardsToMeld(m.id, droppedIds);
-                  setDraggingCardId(null);
-                  setDragOverCardId(null);
-                  setDragOverMeldId(null);
-                }}
-              ><div className="text-sm font-medium">{formatMeldLabel(m, i)}</div><div className="flex flex-wrap gap-1">{m.cards.map(c=><span key={c.id} className={`px-1.5 py-0.5 rounded ${cardColorClass(c)} ${state.turnAddedCardIds?.includes(c.id) ? "bg-amber-200 ring-1 ring-amber-400" : ""}`}>{cardLabel(c)}</span>)}</div></div>;
-            })}
-            {!state.round.tableMelds.length && <div className="text-sm text-slate-600">No melds yet.</div>}
-          </div>
+          <section className="p-3 rounded-2xl bg-emerald-950/40 border border-emerald-300/20">
+            <div className="font-semibold text-emerald-50">Table melds</div>
+            <div className="grid md:grid-cols-2 gap-2 mt-2">
+              {state.round.tableMelds.map((m, i)=>{
+                const isMeldDropTarget = dragOverMeldId === m.id;
+                return <div
+                  className={`border border-white/15 rounded-xl p-2 bg-slate-900/40 ${isMeldDropTarget ? "ring-2 ring-emerald-300" : ""}`}
+                  key={m.id}
+                  onDragOver={e=>{
+                    if(!draggingCardId) return;
+                    e.preventDefault();
+                    setDragOverMeldId(m.id);
+                  }}
+                  onDragLeave={()=>{ if(dragOverMeldId === m.id) setDragOverMeldId(null); }}
+                  onDrop={e=>{
+                    e.preventDefault();
+                    if(!draggingCardId) return;
+                    const hand = state.round.hands.human;
+                    const selectedSet = new Set(selected);
+                    const droppedIds = selectedSet.has(draggingCardId)
+                      ? hand.filter(c=>selectedSet.has(c.id)).map(c=>c.id)
+                      : [draggingCardId];
+                    setMeldTarget(m.id);
+                    addCardsToMeld(m.id, droppedIds);
+                    setDraggingCardId(null);
+                    setDragOverCardId(null);
+                    setDragOverMeldId(null);
+                  }}
+                ><div className="text-sm font-medium mb-2 text-emerald-50">{formatMeldLabel(m, i)}</div><div className="flex flex-wrap gap-2">{m.cards.map(c=><div key={c.id} draggable={true} onDragStart={(e)=>e.preventDefault()} className={`${state.turnAddedCardIds?.includes(c.id) ? "ring-2 ring-amber-400 rounded-xl" : ""}`}><CardFace card={c} /></div>)}</div></div>;
+              })}
+              {!state.round.tableMelds.length && <div className="text-sm text-emerald-100/80">No melds yet.</div>}
+            </div>
+          </section>
         </section>
 
         {state.phase === "roundOver" && <section className="p-3 rounded bg-emerald-50 border border-emerald-300">
@@ -792,14 +938,26 @@
       if(!state || state.phase!=="playing" || state.currentPlayer!=="computer") return state;
       const next = structuredClone(state);
       next.turnAddedCardIds = [];
+      const aiEvents = [];
       const roundDef = ROUND_DEFS[next.roundIndex];
       const hand = next.round.hands.computer;
       const topDiscard = next.round.discard[next.round.discard.length-1];
 
       // draw
       const shouldTakeDiscard = topDiscard && aiWantsCard(topDiscard, hand, roundDef.components, next.round.laid.computer, next.aiLevel);
-      if(shouldTakeDiscard){ hand.push(next.round.discard.pop()); }
-      else if(next.round.deck.length){ hand.push(next.round.deck.pop()); }
+      let drawnCard = null;
+      if(shouldTakeDiscard){
+        drawnCard = next.round.discard.pop();
+        if(drawnCard) hand.push(drawnCard);
+        next.aiLastDrawFrom = "discard";
+        aiEvents.push(`${next.computerName} took ${drawnCard ? cardLabel(drawnCard) : "a card"} from the discard pile`);
+      }
+      else if(next.round.deck.length){
+        drawnCard = next.round.deck.pop();
+        if(drawnCard) hand.push(drawnCard);
+        next.aiLastDrawFrom = "deck";
+        aiEvents.push(`${next.computerName} drew from the deck`);
+      }
       next.hasDrawn = true;
 
       // lay objective melds
@@ -816,6 +974,7 @@
           next.round.laid.computer.push(m.type);
         }
         next.round.hands.computer = next.round.hands.computer.filter(c=>!used.has(c.id));
+        aiEvents.push(`${next.computerName} laid ${newMelds.length} meld${newMelds.length>1?"s":""}`);
       }
 
       // layoff if objective done
@@ -848,7 +1007,8 @@
       next.round.hands.computer = next.round.hands.computer.filter(c=>c.id!==discardCard.id);
       next.currentPlayer = "human";
       next.hasDrawn = false;
-      next.message = `${next.computerName} took a turn and discarded ${cardLabel(discardCard)}.`;
+      aiEvents.push(`${next.computerName} discarded ${cardLabel(discardCard)}`);
+      next.message = aiEvents.join(". ") + ".";
 
       return maybeFinishRound(next, "computer");
     }


### PR DESCRIPTION
### Motivation
- Refresh the visual design to a darker, more modern theme and improve the readability of game state and controls.
- Replace plain text card labels with image-backed SVG card faces to give clearer, tappable visuals for hand and table cards.
- Add a drag-to-draw interaction for drawing from the deck or taking the discard to improve ergonomics and clarity of draws.
- Improve AI feedback and state tracking for better turn messages and visual indicators of where the AI drew from.

### Description
- Bumped app version to `v0.65` and introduced new state fields `lastDrawnCardId`, `aiLastDrawFrom`, and `draggingDrawFrom` to track draw provenance and highlight newly drawn cards.
- Added SVG-based card rendering via `cardImageData`, `cardSuitColor`, and a `CardFace` React helper to render card images, and used these for hand and meld displays.
- Implemented a draw permission check `drawRestriction` and drag-and-drop draw flow with `startDrawDrag` and `draw` updates so dragging deck/discard into the hand triggers a draw and shows a drag image.
- Updated AI behavior to record where it drew from and to accumulate `aiEvents` for clearer messages, increased AI turn delay from `700ms` to `1600ms`, and set `aiLastDrawFrom` appropriately.
- Overhauled UI styling and layout (dark emerald theme, rounded corners, new button styles, deck/discard visuals, and hand/tables redesign) and updated meld/drag handling to accept draw-drags and normal card drag-and-drop interactions.
- Ensured round transitions reset draw-related state (`lastDrawnCardId` and `aiLastDrawFrom`) and updated discard to clear `lastDrawnCardId` after discarding.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699faf766ddc83288b27205343e91621)