### PR TITLE
Add card SVG assets and use external assets with SVG fallback; bump app version

### DIFF
--- a/assets/cards/10_C.svg
+++ b/assets/cards/10_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>10♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>10♣</text>
+</svg>

--- a/assets/cards/10_D.svg
+++ b/assets/cards/10_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>10♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>10♦</text>
+</svg>

--- a/assets/cards/10_H.svg
+++ b/assets/cards/10_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>10♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>10♥</text>
+</svg>

--- a/assets/cards/10_S.svg
+++ b/assets/cards/10_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>10♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>10♠</text>
+</svg>

--- a/assets/cards/2_C.svg
+++ b/assets/cards/2_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>2♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>2♣</text>
+</svg>

--- a/assets/cards/2_D.svg
+++ b/assets/cards/2_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>2♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>2♦</text>
+</svg>

--- a/assets/cards/2_H.svg
+++ b/assets/cards/2_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>2♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>2♥</text>
+</svg>

--- a/assets/cards/2_S.svg
+++ b/assets/cards/2_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>2♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>2♠</text>
+</svg>

--- a/assets/cards/3_C.svg
+++ b/assets/cards/3_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>3♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>3♣</text>
+</svg>

--- a/assets/cards/3_D.svg
+++ b/assets/cards/3_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>3♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>3♦</text>
+</svg>

--- a/assets/cards/3_H.svg
+++ b/assets/cards/3_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>3♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>3♥</text>
+</svg>

--- a/assets/cards/3_S.svg
+++ b/assets/cards/3_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>3♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>3♠</text>
+</svg>

--- a/assets/cards/4_C.svg
+++ b/assets/cards/4_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>4♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>4♣</text>
+</svg>

--- a/assets/cards/4_D.svg
+++ b/assets/cards/4_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>4♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>4♦</text>
+</svg>

--- a/assets/cards/4_H.svg
+++ b/assets/cards/4_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>4♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>4♥</text>
+</svg>

--- a/assets/cards/4_S.svg
+++ b/assets/cards/4_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>4♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>4♠</text>
+</svg>

--- a/assets/cards/5_C.svg
+++ b/assets/cards/5_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>5♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>5♣</text>
+</svg>

--- a/assets/cards/5_D.svg
+++ b/assets/cards/5_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>5♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>5♦</text>
+</svg>

--- a/assets/cards/5_H.svg
+++ b/assets/cards/5_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>5♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>5♥</text>
+</svg>

--- a/assets/cards/5_S.svg
+++ b/assets/cards/5_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>5♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>5♠</text>
+</svg>

--- a/assets/cards/6_C.svg
+++ b/assets/cards/6_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>6♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>6♣</text>
+</svg>

--- a/assets/cards/6_D.svg
+++ b/assets/cards/6_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>6♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>6♦</text>
+</svg>

--- a/assets/cards/6_H.svg
+++ b/assets/cards/6_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>6♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>6♥</text>
+</svg>

--- a/assets/cards/6_S.svg
+++ b/assets/cards/6_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>6♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>6♠</text>
+</svg>

--- a/assets/cards/7_C.svg
+++ b/assets/cards/7_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>7♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>7♣</text>
+</svg>

--- a/assets/cards/7_D.svg
+++ b/assets/cards/7_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>7♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>7♦</text>
+</svg>

--- a/assets/cards/7_H.svg
+++ b/assets/cards/7_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>7♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>7♥</text>
+</svg>

--- a/assets/cards/7_S.svg
+++ b/assets/cards/7_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>7♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>7♠</text>
+</svg>

--- a/assets/cards/8_C.svg
+++ b/assets/cards/8_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>8♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>8♣</text>
+</svg>

--- a/assets/cards/8_D.svg
+++ b/assets/cards/8_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>8♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>8♦</text>
+</svg>

--- a/assets/cards/8_H.svg
+++ b/assets/cards/8_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>8♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>8♥</text>
+</svg>

--- a/assets/cards/8_S.svg
+++ b/assets/cards/8_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>8♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>8♠</text>
+</svg>

--- a/assets/cards/9_C.svg
+++ b/assets/cards/9_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>9♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>9♣</text>
+</svg>

--- a/assets/cards/9_D.svg
+++ b/assets/cards/9_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>9♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>9♦</text>
+</svg>

--- a/assets/cards/9_H.svg
+++ b/assets/cards/9_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>9♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>9♥</text>
+</svg>

--- a/assets/cards/9_S.svg
+++ b/assets/cards/9_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>9♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>9♠</text>
+</svg>

--- a/assets/cards/A_C.svg
+++ b/assets/cards/A_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>A♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>A♣</text>
+</svg>

--- a/assets/cards/A_D.svg
+++ b/assets/cards/A_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>A♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>A♦</text>
+</svg>

--- a/assets/cards/A_H.svg
+++ b/assets/cards/A_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>A♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>A♥</text>
+</svg>

--- a/assets/cards/A_S.svg
+++ b/assets/cards/A_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>A♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>A♠</text>
+</svg>

--- a/assets/cards/BACK.svg
+++ b/assets/cards/BACK.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#e2e8f0' stroke='#94a3b8' stroke-width='6'/>
+  <rect x='24' y='24' width='132' height='202' rx='14' fill='#1e293b' opacity='0.9'/>
+  <circle cx='90' cy='125' r='34' fill='#334155'/>
+  <text x='90' y='134' text-anchor='middle' font-size='30' font-family='Arial,sans-serif' fill='#e2e8f0'>C</text>
+</svg>

--- a/assets/cards/JOKER_1.svg
+++ b/assets/cards/JOKER_1.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='30' font-family='Arial,sans-serif' fill='#ef4444' font-weight='700'>JOKER</text>
+  <text x='90' y='146' text-anchor='middle' font-size='72' font-family='Arial,sans-serif' fill='#ef4444'>🃏</text>
+  <text x='160' y='226' text-anchor='end' font-size='30' font-family='Arial,sans-serif' fill='#ef4444' font-weight='700'>JOKER</text>
+</svg>

--- a/assets/cards/JOKER_2.svg
+++ b/assets/cards/JOKER_2.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='30' font-family='Arial,sans-serif' fill='#0891b2' font-weight='700'>JOKER</text>
+  <text x='90' y='146' text-anchor='middle' font-size='72' font-family='Arial,sans-serif' fill='#0891b2'>🃏</text>
+  <text x='160' y='226' text-anchor='end' font-size='30' font-family='Arial,sans-serif' fill='#0891b2' font-weight='700'>JOKER</text>
+</svg>

--- a/assets/cards/J_C.svg
+++ b/assets/cards/J_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>J♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>J♣</text>
+</svg>

--- a/assets/cards/J_D.svg
+++ b/assets/cards/J_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>J♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>J♦</text>
+</svg>

--- a/assets/cards/J_H.svg
+++ b/assets/cards/J_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>J♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>J♥</text>
+</svg>

--- a/assets/cards/J_S.svg
+++ b/assets/cards/J_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>J♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>J♠</text>
+</svg>

--- a/assets/cards/K_C.svg
+++ b/assets/cards/K_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>K♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>K♣</text>
+</svg>

--- a/assets/cards/K_D.svg
+++ b/assets/cards/K_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>K♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>K♦</text>
+</svg>

--- a/assets/cards/K_H.svg
+++ b/assets/cards/K_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>K♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>K♥</text>
+</svg>

--- a/assets/cards/K_S.svg
+++ b/assets/cards/K_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>K♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>K♠</text>
+</svg>

--- a/assets/cards/Q_C.svg
+++ b/assets/cards/Q_C.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>Q♣</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♣</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>Q♣</text>
+</svg>

--- a/assets/cards/Q_D.svg
+++ b/assets/cards/Q_D.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>Q♦</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♦</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>Q♦</text>
+</svg>

--- a/assets/cards/Q_H.svg
+++ b/assets/cards/Q_H.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>Q♥</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#dc2626'>♥</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#dc2626' font-weight='700'>Q♥</text>
+</svg>

--- a/assets/cards/Q_S.svg
+++ b/assets/cards/Q_S.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
+  <rect x='5' y='5' width='170' height='240' rx='18' fill='#ffffff' stroke='#cbd5e1' stroke-width='6'/>
+  <text x='20' y='52' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>Q♠</text>
+  <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Arial,sans-serif' fill='#0f172a'>♠</text>
+  <text x='160' y='226' text-anchor='end' font-size='36' font-family='Arial,sans-serif' fill='#0f172a' font-weight='700'>Q♠</text>
+</svg>

--- a/carioca-game.html
+++ b/carioca-game.html
@@ -24,7 +24,7 @@
   <script type="text/babel">
     const { useEffect, useMemo, useState } = React;
 
-    const APP_VERSION = "v0.66";
+    const APP_VERSION = "v0.68";
 
     const NS = "carioca-game-v2";
     const GAMES_KEY = NS + ":games";
@@ -80,7 +80,25 @@
       if(c.joker || !c.suit) return "#1e293b";
       return RED_SUITS.has(c.suit) ? "#dc2626" : "#0f172a";
     }
-    function cardImageData(c, selected=false){
+    function cardAssetKey(c){
+      if(c.joker){
+        const parity = [...c.id].reduce((sum, ch)=>sum + ch.charCodeAt(0), 0) % 2;
+        return `JOKER_${parity+1}`;
+      }
+      const suitMap = { "♠":"S", "♥":"H", "♦":"D", "♣":"C" };
+      return `${c.rank}_${suitMap[c.suit]}`;
+    }
+    function cardAssetPath(filename){
+      try { return new URL(`assets/cards/${filename}`, window.location.href).href; }
+      catch { return `assets/cards/${filename}`; }
+    }
+    function cardImageData(c){
+      return cardAssetPath(`${cardAssetKey(c)}.svg`);
+    }
+    function cardBackImageData(){
+      return cardAssetPath("BACK.svg");
+    }
+    function cardSvgFallbackData(c, selected=false){
       const rank = c.joker ? "JOKER" : c.rank;
       const suit = c.joker ? "★" : c.suit;
       const color = selected ? "#ffffff" : cardSuitColor(c);
@@ -93,15 +111,6 @@
         <text x='20' y='52' font-size='36' font-family='Inter,Arial,sans-serif' fill='${color}' font-weight='800'>${top}</text>
         <text x='90' y='146' text-anchor='middle' font-size='84' font-family='Inter,Arial,sans-serif' fill='${color}'>${center}</text>
         <text x='160' y='226' text-anchor='end' font-size='36' font-family='Inter,Arial,sans-serif' fill='${color}' font-weight='800'>${top}</text>
-      </svg>`;
-      return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
-    }
-    function cardBackImageData(){
-      const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 250'>
-        <rect x='5' y='5' width='170' height='240' rx='18' fill='#e2e8f0' stroke='#94a3b8' stroke-width='6'/>
-        <rect x='24' y='24' width='132' height='202' rx='14' fill='#1e293b' opacity='0.9'/>
-        <circle cx='90' cy='125' r='34' fill='#334155'/>
-        <text x='90' y='134' text-anchor='middle' font-size='30' font-family='Inter,Arial,sans-serif' fill='#e2e8f0'>C</text>
       </svg>`;
       return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
     }
@@ -710,7 +719,7 @@
         e.dataTransfer.effectAllowed = "move";
         e.dataTransfer.setData("text/plain", `draw:${from}`);
         const img = new Image();
-        img.src = from === "deck" ? cardBackImageData() : cardImageData(card, false);
+        img.src = from === "deck" ? cardBackImageData() : cardImageData(card);
         img.style.position = "absolute";
         img.style.left = "-9999px";
         img.style.width = "56px";
@@ -723,9 +732,14 @@
 
       function CardFace({ card, selected: isSelected=false, highlight=false, className="" }){
         return <img
-          src={cardImageData(card, isSelected)}
+          src={cardImageData(card)}
           alt={cardLabel(card)}
-          className={`h-20 w-14 rounded-lg border border-slate-300/80 shadow-sm bg-white object-cover select-none ${highlight ? "ring-2 ring-emerald-400" : ""} ${className}`}
+          onError={(e)=>{
+            if(e.currentTarget.dataset.fallbackApplied === "1") return;
+            e.currentTarget.dataset.fallbackApplied = "1";
+            e.currentTarget.src = cardSvgFallbackData(card, isSelected);
+          }}
+          className={`h-20 w-14 rounded-lg border border-slate-300/80 shadow-sm bg-white object-cover select-none ${highlight ? "ring-2 ring-emerald-400" : ""} ${isSelected ? "ring-2 ring-sky-500" : ""} ${className}`}
           draggable={false}
         />;
       }


### PR DESCRIPTION
### Motivation

- Provide full set of card face and back images as SVG assets to replace inline/generated card images and support richer visuals.
- Switch runtime card rendering from embedded data-URIs to referencing asset files so cards can be cached and updated independently.
- Add a robust fallback mechanism so UI still renders if an asset fails to load.

### Description

- Added a complete deck of new SVG assets under `assets/cards/` including `A..K`, `2..10`, `JOKER_1`, `JOKER_2`, and `BACK.svg` files for each suit suffix `_C`, `_D`, `_H`, `_S`.
- Reworked card image logic in `carioca-game.html` by introducing `cardAssetKey`, `cardAssetPath`, `cardImageData`, and `cardBackImageData` to produce asset URLs instead of inline SVG data URIs.
- Preserved the inline SVG generator as `cardSvgFallbackData(c, selected)` and added `onError` handling on the `img` element to swap to the fallback SVG when an asset fails to load, with a `data-fallbackApplied` guard.
- Minor UI tweaks: added selection ring class to card faces and bumped `APP_VERSION` from `v0.66` to `v0.68`.

### Testing

- No automated tests were added or modified for these changes.  
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e35ff1248328b81c848578e2aa6c)