### PR TITLE
Switch gameplay card faces to assets/svg_cards

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -83,20 +83,24 @@
     function cardAssetKey(c){
       if(c.joker){
         const parity = [...c.id].reduce((sum, ch)=>sum + ch.charCodeAt(0), 0) % 2;
-        return `JOKER_${parity+1}`;
+        return parity === 0 ? "black_joker" : "red_joker";
       }
-      const suitMap = { "♠":"S", "♥":"H", "♦":"D", "♣":"C" };
-      return `${c.rank}_${suitMap[c.suit]}`;
+      const rankMap = {
+        A:"ace", J:"jack", Q:"queen", K:"king",
+        "2":"2", "3":"3", "4":"4", "5":"5", "6":"6", "7":"7", "8":"8", "9":"9", "10":"10"
+      };
+      const suitMap = { "♠":"spades", "♥":"hearts", "♦":"diamonds", "♣":"clubs" };
+      return `${rankMap[c.rank]}_of_${suitMap[c.suit]}`;
     }
     function cardAssetPath(filename){
-      try { return new URL(`assets/cards/${filename}`, window.location.href).href; }
-      catch { return `assets/cards/${filename}`; }
+      try { return new URL(`assets/svg_cards/${filename}`, window.location.href).href; }
+      catch { return `assets/svg_cards/${filename}`; }
     }
     function cardImageData(c){
       return cardAssetPath(`${cardAssetKey(c)}.svg`);
     }
     function cardBackImageData(){
-      return cardAssetPath("BACK.svg");
+      return "assets/cards/BACK.svg";
     }
     function cardSvgFallbackData(c, selected=false){
       const rank = c.joker ? "JOKER" : c.rank;
@@ -803,7 +807,7 @@
             <div className="mt-3 flex flex-wrap gap-1.5 min-h-[74px] items-end relative">
               {state.aiDrawPreviewCard && (
                 <img
-                  src={state.aiLastDrawFrom === "deck" ? "assets/cards/BACK.svg" : cardImageData(state.aiDrawPreviewCard)}
+                  src={state.aiLastDrawFrom === "deck" ? cardBackImageData() : cardImageData(state.aiDrawPreviewCard)}
                   alt="AI draw"
                   className="pointer-events-none absolute left-1 top-1 h-20 w-14 rounded-lg border border-amber-200/60 shadow-lg animate-[aiDraw_900ms_ease-out]"
                 />


### PR DESCRIPTION
### Motivation
- Replace the game's raster/SVG face assets mapping so the in-game card faces use the `assets/svg_cards` set already included in the repo.

### Description
- Updated `cardAssetKey` in `carioca-game.html` to produce names matching the `assets/svg_cards` scheme (e.g. `ace_of_spades`, `10_of_hearts`, `red_joker`/`black_joker`).
- Changed `cardAssetPath` to resolve filenames under `assets/svg_cards` so face images load from the new folder.
- Kept the physical deck back image on the existing `assets/cards/BACK.svg` and adjusted `cardBackImageData()` to return that path directly.
- Replaced the AI draw preview hardcoded back-path with a call to `cardBackImageData()` to centralize back-card references.

### Testing
- Ran `rg` to verify updated references to `assets/svg_cards` and helper functions in `carioca-game.html` (succeeded).
- Launched a local static server with `python3 -m http.server 4173 --bind 0.0.0.0` and confirmed the app served (succeeded).
- Loaded `http://127.0.0.1:4173/carioca-game.html` via an automated Playwright script and captured a screenshot showing card face requests served from `assets/svg_cards` with HTTP 200 responses (succeeded).
- Committed the change with `git commit` after verification (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72d0870e88328991acb17647136b6)