### PR TITLE
Bump APP_VERSION to v0.69 and adjust SUIT_ORDER

### DIFF
--- a/carioca-game.html
+++ b/carioca-game.html
@@ -24,7 +24,7 @@
   <script type="text/babel">
     const { useEffect, useMemo, useState } = React;
 
-    const APP_VERSION = "v0.68";
+    const APP_VERSION = "v0.69";
 
     const NS = "carioca-game-v2";
     const GAMES_KEY = NS + ":games";
@@ -36,7 +36,7 @@
     const RANKS = ["A","2","3","4","5","6","7","8","9","10","J","Q","K"];
     const RED_SUITS = new Set(["♥","♦"]);
     const BLACK_SUITS = new Set(["♠","♣"]);
-    const SUIT_ORDER = ["♠", "♥", "♦", "♣"];
+    const SUIT_ORDER = ["♠", "♥", "♣", "♦"];
 
     const AI_LEVELS = ["Easy", "Medium", "Hard"];
     const ROUND_DEFS = [


### PR DESCRIPTION
### Motivation
- Bump the app version and correct the in-memory suit ordering used for sorting/comparisons by changing `SUIT_ORDER` to `['♠','♥','♣','♦']`.

### Description
- Updated `APP_VERSION` to `v0.69` and modified the `SUIT_ORDER` constant in `carioca-game.html` to change the relative order of clubs and diamonds.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b6924e4883289dd4dba7af67457d)